### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glennib-thelib"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "glennib-theotherserver"

--- a/crates/thelib/CHANGELOG.md
+++ b/crates/thelib/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/glennib/example-workspace-rs/compare/glennib-thelib-v0.1.0...glennib-thelib-v0.1.1) - 2024-04-25
+
+### Added
+- add not_prime
+
+### Other
+- update description
+
 ## [0.1.0](https://github.com/glennib/example-workspace-rs/releases/tag/thelib-v0.1.0) - 2024-04-25
 
 ### Other

--- a/crates/thelib/Cargo.toml
+++ b/crates/thelib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glennib-thelib"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Glenn Bitar <glennbitar@gmail.com>"]
 description = "Test library for testing release-plz"

--- a/crates/theotherserver/Cargo.toml
+++ b/crates/theotherserver/Cargo.toml
@@ -11,7 +11,7 @@ license = "Unlicense"
 anyhow = "1.0.82"
 axum = "0.7.5"
 clap = { version = "4.5.4", features = ["derive"] }
-thelib = { package = "glennib-thelib", version = "0.1.0", path = "../thelib" }
+thelib = { package = "glennib-thelib", version = "0.1.1", path = "../thelib" }
 tokio = { version = "1.37.0", features = ["full"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"

--- a/crates/theserver/Cargo.toml
+++ b/crates/theserver/Cargo.toml
@@ -11,7 +11,7 @@ license = "Unlicense"
 anyhow = "1.0.82"
 axum = "0.7.5"
 clap = { version = "4.5.4", features = ["derive"] }
-thelib = { package = "glennib-thelib", version = "0.1.0", path = "../thelib" }
+thelib = { package = "glennib-thelib", version = "0.1.1", path = "../thelib" }
 tokio = { version = "1.37.0", features = ["full"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"


### PR DESCRIPTION
## 🤖 New release
* `glennib-thelib`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/glennib/example-workspace-rs/compare/glennib-thelib-v0.1.0...glennib-thelib-v0.1.1) - 2024-04-25

### Added
- add not_prime

### Other
- update description
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).