### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glennib-thelib"
-version = "0.1.1"
+version = "0.1.2"
 
 [[package]]
 name = "glennib-theotherserver"
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "glennib-theserver"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/thelib/CHANGELOG.md
+++ b/crates/thelib/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/glennib/example-workspace-rs/compare/glennib-thelib-v0.1.1...glennib-thelib-v0.1.2) - 2024-04-25
+
+### Added
+- succ
+
 ## [0.1.1](https://github.com/glennib/example-workspace-rs/compare/glennib-thelib-v0.1.0...glennib-thelib-v0.1.1) - 2024-04-25
 
 ### Added

--- a/crates/thelib/Cargo.toml
+++ b/crates/thelib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glennib-thelib"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Glenn Bitar <glennbitar@gmail.com>"]
 description = "Test library for testing release-plz"

--- a/crates/theotherserver/Cargo.toml
+++ b/crates/theotherserver/Cargo.toml
@@ -11,7 +11,7 @@ license = "Unlicense"
 anyhow = "1.0.82"
 axum = "0.7.5"
 clap = { version = "4.5.4", features = ["derive"] }
-thelib = { package = "glennib-thelib", version = "0.1.1", path = "../thelib" }
+thelib = { package = "glennib-thelib", version = "0.1.2", path = "../thelib" }
 tokio = { version = "1.37.0", features = ["full"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"

--- a/crates/theserver/CHANGELOG.md
+++ b/crates/theserver/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/glennib/example-workspace-rs/compare/glennib-theserver-v0.1.1...glennib-theserver-v0.1.2) - 2024-04-25
+
+### Added
+- add succ path
+
 ## [0.1.1](https://github.com/glennib/example-workspace-rs/compare/glennib-theserver-v0.1.0...glennib-theserver-v0.1.1) - 2024-04-25
 
 ### Added

--- a/crates/theserver/Cargo.toml
+++ b/crates/theserver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glennib-theserver"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Unlicense"
 description = "A server that uses thelib"
@@ -11,7 +11,7 @@ description = "A server that uses thelib"
 anyhow = "1.0.82"
 axum = "0.7.5"
 clap = { version = "4.5.4", features = ["derive"] }
-thelib = { package = "glennib-thelib", version = "0.1.1", path = "../thelib" }
+thelib = { package = "glennib-thelib", version = "0.1.2", path = "../thelib" }
 tokio = { version = "1.37.0", features = ["full"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"


### PR DESCRIPTION
## 🤖 New release
* `glennib-thelib`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `glennib-theserver`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `glennib-thelib`
<blockquote>

## [0.1.2](https://github.com/glennib/example-workspace-rs/compare/glennib-thelib-v0.1.1...glennib-thelib-v0.1.2) - 2024-04-25

### Added
- succ
</blockquote>

## `glennib-theserver`
<blockquote>

## [0.1.2](https://github.com/glennib/example-workspace-rs/compare/glennib-theserver-v0.1.1...glennib-theserver-v0.1.2) - 2024-04-25

### Added
- add succ path
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).